### PR TITLE
Return no hits when trying to find one resource and no mapping exists

### DIFF
--- a/eve_elastic/elastic.py
+++ b/eve_elastic/elastic.py
@@ -243,7 +243,13 @@ class Elastic(DataLayer):
             query['aggs'] = source_config['aggregations']
 
         args = self._es_args(resource)
-        hits = self.es.search(body=query, **args)
+        try:
+            hits = self.es.search(body=query, **args)
+        except elasticsearch.exceptions.RequestError as e:
+            if e.status_code == 400 and "No mapping found for" in e.error:
+                hits = {}
+            else:
+                raise
         return self._parse_hits(hits, resource)
 
     def find_one(self, resource, req, **lookup):

--- a/eve_elastic/test/test_elastic.py
+++ b/eve_elastic/test/test_elastic.py
@@ -348,3 +348,11 @@ class TestElastic(TestCase):
             cursor = self.app.data.find('items', req, None)
             self.assertEqual(2, cursor.count())
             self.assertEqual('foo', cursor[0]['uri'])
+
+    def test_elastic_find_default_sort_no_mapping(self):
+        self.app.data.es.indices.delete_mapping(INDEX, '_all')
+        with self.app.test_request_context('/items/'):
+            req = parse_request('items')
+            req.args = {}
+            cursor = self.app.data.find('items', req, None)
+            self.assertEqual(0, cursor.count())


### PR DESCRIPTION
This PR is long overdue. But, 

When there is no mapping in Elasticsearch and the default sort parameter
is set in a resource's datasource configuration, attempting to search
raises an elasticsearch.exceptions.TransportError. Normally, I would just
create a pull request. But, some people prefer that people talk with them
about the error and how to solve it first.

Here is the log output:
https://gist.github.com/niaquinto/b138fc7e9b610f00408c

I've put together a fork with a unit test that demonstrates the
error (with a failing unit test):
https://github.com/niaquinto/eve-elastic/commit/d375c3ece0da8972a713f06ad459da69b92dbe89

And, I have an update that solves the problem (also making the unit test pass):
https://github.com/niaquinto/eve-elastic/commit/452fe735f5d94ed9468c39e881ba99dec559dedc