### PR TITLE
feat(config): add `auto_aggregations` config

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -43,6 +43,9 @@ There are 2 options for Eve-Elastic taken from ``app.config``:
 
 - ``ELASTICSEARCH_URL`` (default: ``'http://localhost:9200/'``)
 - ``ELASTICSEARCH_INDEX`` - (default: ``'eve'``)
+- ``ELASTICSEARCH_INDEXES`` - (default: ``{}``) - ``resource`` to ``index`` mapping
+- ``ELASTICSEARCH_FORCE_REFRESH`` - (default: ``False``) - force index refresh after every modification
+- ``ELASTICSEARCH_AUTO_AGGREGATIONS`` - (default: ``True``) - return aggregates on every search if configured for resource
 
 Query params
 ------------

--- a/eve_elastic/elastic.py
+++ b/eve_elastic/elastic.py
@@ -164,6 +164,7 @@ class Elastic(DataLayer):
         app.config.setdefault('ELASTICSEARCH_INDEX', 'eve')
         app.config.setdefault('ELASTICSEARCH_INDEXES', {})
         app.config.setdefault('ELASTICSEARCH_FORCE_REFRESH', True)
+        app.config.setdefault('ELASTICSEARCH_AUTO_AGGREGATIONS', True)
 
         self.index = app.config['ELASTICSEARCH_INDEX']
         self.es = get_es(app.config['ELASTICSEARCH_URL'], **self.kwargs)
@@ -332,7 +333,7 @@ class Elastic(DataLayer):
         if 'facets' in source_config:
             query['facets'] = source_config['facets']
 
-        if 'aggregations' in source_config:
+        if 'aggregations' in source_config and self.should_aggregate(req):
             query['aggs'] = source_config['aggregations']
 
         args = self._es_args(resource)
@@ -346,6 +347,9 @@ class Elastic(DataLayer):
             else:
                 raise
         return self._parse_hits(hits, resource)
+
+    def should_aggregate(self, req):
+        return current_app.config.get('ELASTICSEARCH_AUTO_AGGREGATIONS') or req.args.get('aggregations')
 
     def find_one(self, resource, req, **lookup):
 

--- a/test/test_elastic.py
+++ b/test/test_elastic.py
@@ -328,6 +328,22 @@ class TestElastic(TestCase):
             self.assertEqual(1, item2.count())
             self.assertEqual(3, response['_aggregations']['type']['buckets'][0]['doc_count'])
 
+    def test_resource_aggregates_no_auto(self):
+        with self.app.app_context():
+            self.app.data.insert('items_with_description', [{'uri': 'foo'}])
+            self.app.config['ELASTICSEARCH_AUTO_AGGREGATIONS'] = False
+            req = ParsedRequest()
+            req.args = {}
+            response = {}
+            cursor = self.app.data.find('items_with_description', req, {})
+            cursor.extra(response)
+            self.assertNotIn('_aggregations', response)
+
+            req.args = {'aggregations': 1}
+            cursor = self.app.data.find('items_with_description', req, {})
+            cursor.extra(response)
+            self.assertIn('_aggregations', response)
+
     def test_put(self):
         with self.app.app_context():
             self.app.data.replace('items', 'newid', {'uri': 'foo', '_id': 'newid', '_type': 'x'})


### PR DESCRIPTION
instead of doing aggregations on every search request only do this
if client requests aggregations. default is do aggregations always.