### PR TITLE
Modified init_index method to call put_mapping irrespective of index exists or not.

### DIFF
--- a/eve_elastic/elastic.py
+++ b/eve_elastic/elastic.py
@@ -176,7 +176,8 @@ class Elastic(DataLayer):
         for index in indexes:
             if not self.es.indices.exists(index):
                 self.create_index(index, app.config.get('ELASTICSEARCH_SETTINGS'))
-                self.put_mapping(app, index)
+
+            self.put_mapping(app, index)
 
     def get_datasource(self, resource):
         if hasattr(self, '_datasource'):

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ with open('LICENSE') as f:
 
 setup(
     name='Eve-Elastic',
-    version='0.3.3',
+    version='0.3.4',
     description='Elasticsearch data layer for eve rest framework',
     long_description=readme + '\n\n' + changelog,
     license=license,


### PR DESCRIPTION
The call to `init_index` from `init_app` creates indices but does not  apply mapping as `DOMAIN` is not set. Hence, modified `init_index` method to call `put_mapping` irrespective of index exists or not.