### PR TITLE
update to use eve_elastic with ElasticSearch 2.3

### DIFF
--- a/eve_elastic/elastic.py
+++ b/eve_elastic/elastic.py
@@ -257,7 +257,6 @@ class Elastic(DataLayer):
                 'index': index or self.index,
                 'doc_type': resource,
                 'body': properties,
-                'ignore_conflicts': True,
             }
 
             try:

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
     tests_require=['nose'],
     install_requires=[
         'arrow>=0.4.2',
-        'elasticsearch>=1.2.0,<2.0.0',
+        'elasticsearch>=1.2.0,<3.0.0',
         'Eve>=0.4',
     ],
     classifiers=[


### PR DESCRIPTION
This PR remove ignore_conflict, _id mapping, and replace the use of deprecated "filtered", "and", "not" and "query" filter.
