### PR TITLE
fix(highlights) - Enabling highlights to use call back function

### DIFF
--- a/eve_elastic/elastic.py
+++ b/eve_elastic/elastic.py
@@ -427,8 +427,12 @@ class Elastic(DataLayer):
             query['aggs'] = source_config['aggregations']
 
         if 'es_highlight' in source_config and self.should_highlight(req):
-            query['highlight'] = source_config['es_highlight']
-            query['highlight'].setdefault('require_field_match', False)
+            query_string = query['query'].get('filtered', {}).get('query', {}).get('query_string')
+            highlights = source_config.get('es_highlight', noop)(query_string)
+
+            if highlights:
+                query['highlight'] = highlights
+                query['highlight'].setdefault('require_field_match', False)
 
         source_projections = None
         if self.should_project(req):

--- a/test/test_elastic.py
+++ b/test/test_elastic.py
@@ -12,6 +12,22 @@ from eve_elastic.elastic import parse_date, Elastic, get_indices, get_es, genera
 from nose.tools import raises
 
 
+def highlight_callback(query_string):
+    elastic_highlight_query = {
+        'pre_tags': ['<span class=\"es-highlight\">'],
+        'post_tags': ['</span>'],
+        'fields': {
+            'name': {'number_of_fragments': 0},
+            'description': {'number_of_fragments': 0}
+        }
+    }
+
+    if query_string:
+        for key in elastic_highlight_query['fields']:
+            elastic_highlight_query['fields'][key]['highlight_query'] = {'query_string': query_string}
+        return elastic_highlight_query
+
+
 DOMAIN = {
     'items': {
         'schema': {
@@ -72,14 +88,7 @@ DOMAIN = {
             'default_sort': [('firstcreated', -1)],
             'elastic_filter': {'exists': {'field': 'description'}},
             'aggregations': {'type': {'terms': {'field': 'name'}}},
-            'es_highlight': {
-                                'pre_tags': ['<span class=\"es-highlight\">'],
-                                'post_tags': ['</span>'],
-                                'fields': {
-                                    'name': {'number_of_fragments': 0},
-                                    'description': {'number_of_fragments': 0}
-                                }
-            }
+            'es_highlight': highlight_callback
         }
     },
     'items_with_callback_filter': {


### PR DESCRIPTION
Elastic 2.x highlights the fields using the terms filters as well as the query_string. So if the query_string is "Plane Crash" highlighted stories has "killed" or "submitted" highlighted if those words are available. So changing `es_highlight` to a callback function where highlight queries can be formed per field.