### PR TITLE
only put new settings if those are different to existing ones

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,22 +23,6 @@ matrix:
                   packages:
                       - elasticsearch
 
-        - env: ELASTIC=2X
-          python: "3.4"
-          addons:
-              apt:
-                  sources:
-                      - elasticsearch-2.x
-                  packages:
-                      - elasticsearch
-
-        - env: ELASTIC=2X
-          python: "2.7"
-          addons:
-              apt:
-                  sources:
-                      - elasticsearch-2.x
-                  packages:
                       - elasticsearch
 
         - env: ELASTIC=17


### PR DESCRIPTION
- this should avoid closing/opening index when not needed
- also dropping testing on python < 3.5, it should still run on older but I want to use some newer asserts in tests