### PR TITLE
Possibility to override doc_type

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 
 # env
 /env
+/venv
 /bin
 /lib
 /include

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,17 +9,21 @@ services:
 
 env:
     matrix:
-        - ELASTIC_LINK=https://download.elastic.co/elasticsearch/release/org/elasticsearch/distribution/deb/elasticsearch/2.4.6/elasticsearch-2.4.6.deb
-        - ELASTIC_LINK=https://download.elastic.co/elasticsearch/elasticsearch/elasticsearch-1.7.6.deb
+        - ELASTIC_LINK=https://download.elastic.co/elasticsearch/release/org/elasticsearch/distribution/tar/elasticsearch/2.4.6/elasticsearch-2.4.6.tar.gz
+#        - ELASTIC_LINK=https://download.elastic.co/elasticsearch/release/org/elasticsearch/distribution/deb/elasticsearch/2.4.6/elasticsearch-2.4.6.deb
+#        - ELASTIC_LINK=https://download.elastic.co/elasticsearch/elasticsearch/elasticsearch-1.7.6.deb
 
 before_install:
-    - curl ${ELASTIC_LINK} -o elasticsearch.deb && sudo dpkg -i --force-confnew elasticsearch.deb && sudo service elasticsearch restart
-    - sudo service elasticsearch start
+#    - curl ${ELASTIC_LINK} -o elasticsearch.deb && sudo dpkg -i --force-confnew elasticsearch.deb && sudo service elasticsearch restart
+    - mkdir /tmp/elasticsearch
+    - wget -O - ${ELASTIC_LINK} | tar xz --directory=/tmp/elasticsearch --strip-components=1
+    - /tmp/elasticsearch/bin/elasticsearch --daemonize --path.data /tmp
     - sleep 10
     - curl http://localhost:9200/_cluster/health
 
 before_script:
    - sleep 10
+   - curl http://localhost:9200/_cluster/health
 
 script:
     - nosetests

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,16 +5,18 @@ dist: bionic
 cache: pip
 
 services:
-    - docker
+    - elasticsearch
 
 env:
     matrix:
-        - ELASTIC_VERSION=2.4.6
-        - ELASTIC_VERSION=1.7.6
+        - ELASTIC_LINK=https://download.elastic.co/elasticsearch/release/org/elasticsearch/distribution/deb/elasticsearch/2.4.6/elasticsearch-2.4.6.deb
+        - ELASTIC_LINK=https://download.elastic.co/elasticsearch/elasticsearch/elasticsearch-1.7.6.deb
 
 before_install:
-    - docker pull "elasticsearch:${ELASTIC_VERSION}"
-    - docker run -d -p 9200:9200 -e "discovery.type=single-node" --tmpfs "/usr/share/elasticsearch/data" "elasticsearch:${ELASTIC_VERSION}"
+    - curl -O ${ELASTIC_LINK} -o elasticsearch.deb && sudo dpkg -i --force-confnew elasticsearch.deb && sudo service elasticsearch restart
+
+before_script:
+   - sleep 10
 
 script:
     - nosetests

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,8 @@ dist: bionic
 
 cache: pip
 
-services:
-  - elasticsearch
+#services:
+#  - elasticsearch
 
 env:
   matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,20 +1,15 @@
 language: python
 
-#dist: bionic
-
 cache: pip
 
-#services:
-#  - elasticsearch
-
-#env:
-#  matrix:
-#    - ELASTIC_LINK=https://download.elastic.co/elasticsearch/release/org/elasticsearch/distribution/tar/elasticsearch/2.4.6/elasticsearch-2.4.6.tar.gz
+env:
+  matrix:
+    - ELASTIC_LINK=https://download.elastic.co/elasticsearch/release/org/elasticsearch/distribution/tar/elasticsearch/2.4.6/elasticsearch-2.4.6.deb
 #    - ELASTIC_LINK=https://download.elastic.co/elasticsearch/elasticsearch/elasticsearch-1.7.6.tar.gz
 
 before_install:
-  - curl -O https://download.elastic.co/elasticsearch/release/org/elasticsearch/distribution/deb/elasticsearch/2.3.0/elasticsearch-2.3.0.deb #&& sudo dpkg -i --force-confnew elasticsearch-2.3.0.deb && sudo service elasticsearch restart
-  - sudo dpkg -i --force-confnew elasticsearch-2.3.0.deb
+  - curl ${ELASTIC_LINK} -o elasticsearch.deb #&& sudo dpkg -i --force-confnew elasticsearch-2.3.0.deb && sudo service elasticsearch restart
+  - sudo dpkg -i --force-confnew elasticsearch.deb
   - sudo sed -i.old 's/-Xms1g/-Xms128m/' /etc/elasticsearch/jvm.options
   - sudo sed -i.old 's/-Xmx1g/-Xmx128m/' /etc/elasticsearch/jvm.options
   - echo -e '-XX:+DisableExplicitGC\n-Djdk.io.permissionsUseCanonicalPath=true\n-Dlog4j.skipJansi=true\n-server\n' | sudo tee -a /etc/elasticsearch/jvm.options

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,26 +5,23 @@ dist: bionic
 cache: pip
 
 services:
-    - elasticsearch
+  - elasticsearch
 
 env:
-    matrix:
-        - ELASTIC_LINK=https://download.elastic.co/elasticsearch/release/org/elasticsearch/distribution/tar/elasticsearch/2.4.6/elasticsearch-2.4.6.tar.gz
-#        - ELASTIC_LINK=https://download.elastic.co/elasticsearch/release/org/elasticsearch/distribution/deb/elasticsearch/2.4.6/elasticsearch-2.4.6.deb
-#        - ELASTIC_LINK=https://download.elastic.co/elasticsearch/elasticsearch/elasticsearch-1.7.6.deb
+  matrix:
+    - ELASTIC_LINK=https://download.elastic.co/elasticsearch/release/org/elasticsearch/distribution/tar/elasticsearch/2.4.6/elasticsearch-2.4.6.tar.gz
+    - ELASTIC_LINK=https://download.elastic.co/elasticsearch/elasticsearch/elasticsearch-1.7.6.tar.gz
 
 before_install:
-#    - curl ${ELASTIC_LINK} -o elasticsearch.deb && sudo dpkg -i --force-confnew elasticsearch.deb && sudo service elasticsearch restart
-    - mkdir /tmp/elasticsearch
-    - wget -O - ${ELASTIC_LINK} | tar xz --directory=/tmp/elasticsearch --strip-components=1
-    - /tmp/elasticsearch/bin/elasticsearch --daemonize --path.data /tmp
-    - sleep 10
-    - curl http://localhost:9200/_cluster/health
+  - mkdir /tmp/elasticsearch
+  - wget -O - ${ELASTIC_LINK} | tar xz --directory=/tmp/elasticsearch --strip-components=1
+  - /tmp/elasticsearch/bin/elasticsearch --daemonize --path.data /tmp
 
 before_script:
    - sleep 10
+   - curl http://localhost:9200/
    - curl http://localhost:9200/_cluster/health
 
 script:
-    - nosetests
-    - flake8
+  - nosetests
+  - flake8

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,18 +4,16 @@ dist: bionic
 
 cache: pip
 
-#services:
-#  - elasticsearch
+services:
+  - elasticsearch
 
-env:
-  matrix:
-    - ELASTIC_LINK=https://download.elastic.co/elasticsearch/release/org/elasticsearch/distribution/tar/elasticsearch/2.4.6/elasticsearch-2.4.6.tar.gz
-    - ELASTIC_LINK=https://download.elastic.co/elasticsearch/elasticsearch/elasticsearch-1.7.6.tar.gz
+#env:
+#  matrix:
+#    - ELASTIC_LINK=https://download.elastic.co/elasticsearch/release/org/elasticsearch/distribution/tar/elasticsearch/2.4.6/elasticsearch-2.4.6.tar.gz
+#    - ELASTIC_LINK=https://download.elastic.co/elasticsearch/elasticsearch/elasticsearch-1.7.6.tar.gz
 
 before_install:
-  - mkdir /tmp/elasticsearch
-  - wget -O - ${ELASTIC_LINK} | tar xz --directory=/tmp/elasticsearch --strip-components=1
-  - /tmp/elasticsearch/bin/elasticsearch --daemonize --path.data /tmp
+  - curl -O https://download.elastic.co/elasticsearch/release/org/elasticsearch/distribution/deb/elasticsearch/2.3.0/elasticsearch-2.3.0.deb && sudo dpkg -i --force-confnew elasticsearch-2.3.0.deb && sudo service elasticsearch restart
 
 before_script:
    - sleep 10

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ env:
         - ELASTIC_LINK=https://download.elastic.co/elasticsearch/elasticsearch/elasticsearch-1.7.6.deb
 
 before_install:
-    - curl -O ${ELASTIC_LINK} -o elasticsearch.deb && sudo dpkg -i --force-confnew elasticsearch.deb && sudo service elasticsearch restart
+    - curl ${ELASTIC_LINK} -o elasticsearch.deb && sudo dpkg -i --force-confnew elasticsearch.deb && sudo service elasticsearch restart
 
 before_script:
    - sleep 10

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,12 @@ services:
 
 before_install:
   - curl -O https://download.elastic.co/elasticsearch/release/org/elasticsearch/distribution/deb/elasticsearch/2.3.0/elasticsearch-2.3.0.deb && sudo dpkg -i --force-confnew elasticsearch-2.3.0.deb && sudo service elasticsearch restart
+  - sudo dpkg -i --force-confnew elasticsearch-7.0.1-amd64.deb
+  - sudo sed -i.old 's/-Xms1g/-Xms128m/' /etc/elasticsearch/jvm.options
+  - sudo sed -i.old 's/-Xmx1g/-Xmx128m/' /etc/elasticsearch/jvm.options
+  - echo -e '-XX:+DisableExplicitGC\n-Djdk.io.permissionsUseCanonicalPath=true\n-Dlog4j.skipJansi=true\n-server\n' | sudo tee -a /etc/elasticsearch/jvm.options
+  - sudo chown -R elasticsearch:elasticsearch /etc/default/elasticsearch
+  - sudo systemctl start elasticsearch
 
 before_script:
    - sleep 10

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,8 @@ dist: bionic
 
 cache: pip
 
-services:
-  - elasticsearch
+#services:
+#  - elasticsearch
 
 #env:
 #  matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,9 @@ env:
 
 before_install:
     - curl ${ELASTIC_LINK} -o elasticsearch.deb && sudo dpkg -i --force-confnew elasticsearch.deb && sudo service elasticsearch restart
+    - sudo service elasticsearch start
+    - sleep 10
+    - curl http://localhost:9200/_cluster/health
 
 before_script:
    - sleep 10

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,16 +5,16 @@ cache: pip
 env:
   matrix:
     - ELASTIC_LINK=https://download.elastic.co/elasticsearch/release/org/elasticsearch/distribution/deb/elasticsearch/2.4.6/elasticsearch-2.4.6.deb
-#    - ELASTIC_LINK=https://download.elastic.co/elasticsearch/elasticsearch/elasticsearch-1.7.6.tar.gz
+    - ELASTIC_LINK=https://download.elastic.co/elasticsearch/elasticsearch/elasticsearch-1.7.6.deb
 
 before_install:
-  - curl -f ${ELASTIC_LINK} -o elasticsearch.deb #&& sudo dpkg -i --force-confnew elasticsearch-2.3.0.deb && sudo service elasticsearch restart
+  - curl -f ${ELASTIC_LINK} -o elasticsearch.deb
   - sudo dpkg -i --force-confnew elasticsearch.deb
-  - sudo sed -i.old 's/-Xms1g/-Xms128m/' /etc/elasticsearch/jvm.options
-  - sudo sed -i.old 's/-Xmx1g/-Xmx128m/' /etc/elasticsearch/jvm.options
-  - echo -e '-XX:+DisableExplicitGC\n-Djdk.io.permissionsUseCanonicalPath=true\n-Dlog4j.skipJansi=true\n-server\n' | sudo tee -a /etc/elasticsearch/jvm.options
+#  - sudo sed -i.old 's/-Xms1g/-Xms128m/' /etc/elasticsearch/jvm.options
+#  - sudo sed -i.old 's/-Xmx1g/-Xmx128m/' /etc/elasticsearch/jvm.options
+#  - echo -e '-XX:+DisableExplicitGC\n-Djdk.io.permissionsUseCanonicalPath=true\n-Dlog4j.skipJansi=true\n-server\n' | sudo tee -a /etc/elasticsearch/jvm.options
   - sudo chown -R elasticsearch:elasticsearch /etc/default/elasticsearch
-  - sudo service elasticsearch start
+#  - sudo service elasticsearch start
   - sudo systemctl start elasticsearch
 
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,11 +10,7 @@ env:
 before_install:
   - curl -f ${ELASTIC_LINK} -o elasticsearch.deb
   - sudo dpkg -i --force-confnew elasticsearch.deb
-#  - sudo sed -i.old 's/-Xms1g/-Xms128m/' /etc/elasticsearch/jvm.options
-#  - sudo sed -i.old 's/-Xmx1g/-Xmx128m/' /etc/elasticsearch/jvm.options
-#  - echo -e '-XX:+DisableExplicitGC\n-Djdk.io.permissionsUseCanonicalPath=true\n-Dlog4j.skipJansi=true\n-server\n' | sudo tee -a /etc/elasticsearch/jvm.options
   - sudo chown -R elasticsearch:elasticsearch /etc/default/elasticsearch
-#  - sudo service elasticsearch start
   - sudo systemctl start elasticsearch
 
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,27 +1,21 @@
 language: python
 
+dist: bionic
+
 cache: pip
 
+services:
+    - docker
+
 env:
-  matrix:
-    - ELASTIC_LINK=https://download.elastic.co/elasticsearch/release/org/elasticsearch/distribution/deb/elasticsearch/2.4.6/elasticsearch-2.4.6.deb
-    - ELASTIC_LINK=https://download.elastic.co/elasticsearch/elasticsearch/elasticsearch-1.7.6.deb
+    matrix:
+        - ELASTIC_VERSION=2.4.6
+        - ELASTIC_VERSION=1.7.6
 
 before_install:
-  - curl -f ${ELASTIC_LINK} -o elasticsearch.deb
-  - sudo dpkg -i --force-confnew elasticsearch.deb
-#  - sudo sed -i.old 's/-Xms1g/-Xms128m/' /etc/elasticsearch/jvm.options
-#  - sudo sed -i.old 's/-Xmx1g/-Xmx128m/' /etc/elasticsearch/jvm.options
-#  - echo -e '-XX:+DisableExplicitGC\n-Djdk.io.permissionsUseCanonicalPath=true\n-Dlog4j.skipJansi=true\n-server\n' | sudo tee -a /etc/elasticsearch/jvm.options
-  - sudo chown -R elasticsearch:elasticsearch /etc/default/elasticsearch
-#  - sudo service elasticsearch start
-  - sudo systemctl start elasticsearch
-
-before_script:
-   - sleep 10
-   - curl http://localhost:9200/
-   - curl http://localhost:9200/_cluster/health
+    - docker pull "elasticsearch:${ELASTIC_VERSION}"
+    - docker run -d -p 9200:9200 -e "discovery.type=single-node" --tmpfs "/usr/share/elasticsearch/data" "elasticsearch:${ELASTIC_VERSION}"
 
 script:
-  - nosetests
-  - flake8
+    - nosetests
+    - flake8

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,8 @@ before_install:
   - sudo sed -i.old 's/-Xmx1g/-Xmx128m/' /etc/elasticsearch/jvm.options
   - echo -e '-XX:+DisableExplicitGC\n-Djdk.io.permissionsUseCanonicalPath=true\n-Dlog4j.skipJansi=true\n-server\n' | sudo tee -a /etc/elasticsearch/jvm.options
   - sudo chown -R elasticsearch:elasticsearch /etc/default/elasticsearch
-  - sudo systemctl start elasticsearch
+  - sudo service elasticsearch restart
+  - sudo systemctl restart elasticsearch
 
 before_script:
    - sleep 10

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,21 +1,27 @@
 language: python
 
-dist: bionic
-
 cache: pip
 
-services:
-    - docker
-
 env:
-    matrix:
-        - ELASTIC_VERSION=2.4.6
-        - ELASTIC_VERSION=1.7.6
+  matrix:
+    - ELASTIC_LINK=https://download.elastic.co/elasticsearch/release/org/elasticsearch/distribution/deb/elasticsearch/2.4.6/elasticsearch-2.4.6.deb
+    - ELASTIC_LINK=https://download.elastic.co/elasticsearch/elasticsearch/elasticsearch-1.7.6.deb
 
 before_install:
-    - docker pull "elasticsearch:${ELASTIC_VERSION}"
-    - docker run -d -p 9200:9200 -e "discovery.type=single-node" --tmpfs "/usr/share/elasticsearch/data" "elasticsearch:${ELASTIC_VERSION}"
+  - curl -f ${ELASTIC_LINK} -o elasticsearch.deb
+  - sudo dpkg -i --force-confnew elasticsearch.deb
+#  - sudo sed -i.old 's/-Xms1g/-Xms128m/' /etc/elasticsearch/jvm.options
+#  - sudo sed -i.old 's/-Xmx1g/-Xmx128m/' /etc/elasticsearch/jvm.options
+#  - echo -e '-XX:+DisableExplicitGC\n-Djdk.io.permissionsUseCanonicalPath=true\n-Dlog4j.skipJansi=true\n-server\n' | sudo tee -a /etc/elasticsearch/jvm.options
+  - sudo chown -R elasticsearch:elasticsearch /etc/default/elasticsearch
+#  - sudo service elasticsearch start
+  - sudo systemctl start elasticsearch
+
+before_script:
+   - sleep 10
+   - curl http://localhost:9200/
+   - curl http://localhost:9200/_cluster/health
 
 script:
-    - nosetests
-    - flake8
+  - nosetests
+  - flake8

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,11 +4,11 @@ cache: pip
 
 env:
   matrix:
-    - ELASTIC_LINK=https://download.elastic.co/elasticsearch/release/org/elasticsearch/distribution/tar/elasticsearch/2.4.6/elasticsearch-2.4.6.deb
+    - ELASTIC_LINK=https://download.elastic.co/elasticsearch/release/org/elasticsearch/distribution/deb/elasticsearch/2.4.6/elasticsearch-2.4.6.deb
 #    - ELASTIC_LINK=https://download.elastic.co/elasticsearch/elasticsearch/elasticsearch-1.7.6.tar.gz
 
 before_install:
-  - curl ${ELASTIC_LINK} -o elasticsearch.deb #&& sudo dpkg -i --force-confnew elasticsearch-2.3.0.deb && sudo service elasticsearch restart
+  - curl -f ${ELASTIC_LINK} -o elasticsearch.deb #&& sudo dpkg -i --force-confnew elasticsearch-2.3.0.deb && sudo service elasticsearch restart
   - sudo dpkg -i --force-confnew elasticsearch.deb
   - sudo sed -i.old 's/-Xms1g/-Xms128m/' /etc/elasticsearch/jvm.options
   - sudo sed -i.old 's/-Xmx1g/-Xmx128m/' /etc/elasticsearch/jvm.options

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: python
 
-dist: bionic
+#dist: bionic
 
 cache: pip
 
@@ -19,8 +19,8 @@ before_install:
   - sudo sed -i.old 's/-Xmx1g/-Xmx128m/' /etc/elasticsearch/jvm.options
   - echo -e '-XX:+DisableExplicitGC\n-Djdk.io.permissionsUseCanonicalPath=true\n-Dlog4j.skipJansi=true\n-server\n' | sudo tee -a /etc/elasticsearch/jvm.options
   - sudo chown -R elasticsearch:elasticsearch /etc/default/elasticsearch
-  - sudo service elasticsearch restart
-  - sudo systemctl restart elasticsearch
+  - sudo service elasticsearch start
+  - sudo systemctl start elasticsearch
 
 before_script:
    - sleep 10

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,8 @@ services:
 #    - ELASTIC_LINK=https://download.elastic.co/elasticsearch/elasticsearch/elasticsearch-1.7.6.tar.gz
 
 before_install:
-  - curl -O https://download.elastic.co/elasticsearch/release/org/elasticsearch/distribution/deb/elasticsearch/2.3.0/elasticsearch-2.3.0.deb && sudo dpkg -i --force-confnew elasticsearch-2.3.0.deb && sudo service elasticsearch restart
-  - sudo dpkg -i --force-confnew elasticsearch-7.0.1-amd64.deb
+  - curl -O https://download.elastic.co/elasticsearch/release/org/elasticsearch/distribution/deb/elasticsearch/2.3.0/elasticsearch-2.3.0.deb #&& sudo dpkg -i --force-confnew elasticsearch-2.3.0.deb && sudo service elasticsearch restart
+  - sudo dpkg -i --force-confnew elasticsearch-2.3.0.deb
   - sudo sed -i.old 's/-Xms1g/-Xms128m/' /etc/elasticsearch/jvm.options
   - sudo sed -i.old 's/-Xmx1g/-Xmx128m/' /etc/elasticsearch/jvm.options
   - echo -e '-XX:+DisableExplicitGC\n-Djdk.io.permissionsUseCanonicalPath=true\n-Dlog4j.skipJansi=true\n-server\n' | sudo tee -a /etc/elasticsearch/jvm.options

--- a/eve_elastic/elastic.py
+++ b/eve_elastic/elastic.py
@@ -623,12 +623,11 @@ class Elastic(DataLayer):
         """Insert document, it must be new if there is ``_id`` in it."""
         ids = []
         es_args = self._es_args(resource)
-        # es_args.update(kwargs)
-        kwargs.update(es_args)
+        es_args.update(kwargs)
         for doc in doc_or_docs:
-            self._update_parent_args(resource, kwargs, doc)
+            self._update_parent_args(resource, es_args, doc)
             _id = doc.pop('_id', None)
-            res = self.elastic(resource).index(body=doc, id=_id, **kwargs)
+            res = self.elastic(resource).index(body=doc, id=_id, **es_args)
             doc.setdefault('_id', res.get('_id', _id))
             ids.append(doc.get('_id'))
         self._refresh_resource_index(resource)

--- a/eve_elastic/elastic.py
+++ b/eve_elastic/elastic.py
@@ -622,11 +622,12 @@ class Elastic(DataLayer):
     def insert(self, resource, doc_or_docs, **kwargs):
         """Insert document, it must be new if there is ``_id`` in it."""
         ids = []
-        kwargs.update(self._es_args(resource))
+        es_args = self._es_args(resource)
+        es_args.update(kwargs)
         for doc in doc_or_docs:
             self._update_parent_args(resource, kwargs, doc)
             _id = doc.pop('_id', None)
-            res = self.elastic(resource).index(body=doc, id=_id, **kwargs)
+            res = self.elastic(resource).index(body=doc, id=_id, **es_args)
             doc.setdefault('_id', res.get('_id', _id))
             ids.append(doc.get('_id'))
         self._refresh_resource_index(resource)

--- a/eve_elastic/elastic.py
+++ b/eve_elastic/elastic.py
@@ -623,11 +623,12 @@ class Elastic(DataLayer):
         """Insert document, it must be new if there is ``_id`` in it."""
         ids = []
         es_args = self._es_args(resource)
-        es_args.update(kwargs)
+        # es_args.update(kwargs)
+        kwargs.update(es_args)
         for doc in doc_or_docs:
             self._update_parent_args(resource, kwargs, doc)
             _id = doc.pop('_id', None)
-            res = self.elastic(resource).index(body=doc, id=_id, **es_args)
+            res = self.elastic(resource).index(body=doc, id=_id, **kwargs)
             doc.setdefault('_id', res.get('_id', _id))
             ids.append(doc.get('_id'))
         self._refresh_resource_index(resource)


### PR DESCRIPTION
I want to pass doc_type kwarg on insert method.
Currently, this value is overridden by `kwargs.update(self._es_args(resource))`, so I changed order.

> I recommend to update this method on other branches too