### PR TITLE
Use elasticsearch <7.14.0

### DIFF
--- a/eve_elastic/elastic.py
+++ b/eve_elastic/elastic.py
@@ -978,7 +978,7 @@ class Elastic(DataLayer):
         return self.elastics[px]
 
     def _get_retry_on_conflict(self):
-        """ Get the retry on settings"""
+        """Get the retry on settings"""
         return app.config.get("ELASTICSEARCH_RETRY_ON_CONFLICT", 5)
 
     def drop_index(self):

--- a/eve_elastic/helpers.py
+++ b/eve_elastic/helpers.py
@@ -17,7 +17,7 @@ logger = logging.getLogger("elasticsearch.helpers")
 class BulkIndexError(ElasticsearchException):
     @property
     def errors(self):
-        """ List of errors from execution of the last chunk. """
+        """List of errors from execution of the last chunk."""
         return self.args[1]
 
 

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
         "arrow>=0.4.2",
         "ciso8601>=1.0.2,<2",
         "pytz>=2015.4",
-        "elasticsearch>=7.0.0,<8.0.0",
+        "elasticsearch>=7.0.0,<7.14.0",
     ],
     classifiers=[
         "Development Status :: 4 - Beta",


### PR DESCRIPTION
From their release notes:
* Added check that client is connected to an Elasticsearch cluster. If the client isn't connected to a supported Elasticsearch cluster the `UnsupportedProductError` exception will be raised.